### PR TITLE
Allow to run the role in check mode

### DIFF
--- a/tasks/detect_mariadb_version.yml
+++ b/tasks/detect_mariadb_version.yml
@@ -5,6 +5,7 @@
     state: available
     package_name: "{{ mariadb_server }}"
     repository: "{{ 'MariaDB' if ansible_os_family | lower == 'redhat' and mariadb_use_external_repo else '' }}"
+  check_mode: false
   register: package_version
 
 - name: define mariadb version

--- a/tasks/install/python-support.yml
+++ b/tasks/install/python-support.yml
@@ -4,6 +4,7 @@
   when:
     - mariadb_python_packages is defined
     - mariadb_python_packages | length > 0
+    - not ansible_check_mode
   block:
     - name: create pip requirements file
       bodsch.core.pip_requirements:


### PR DESCRIPTION
With 2.6.0, a run in `--check` mode fails because of two issues:

## 1. `detect available mariadb version` does not run

So `mariadb_version` and `mariadb_short_version` are not defined.

```
TASK [bodsch.mariadb : mariadb version] *****************************************************************************************************************************************************************************
Friday 30 May 2025  23:21:50 +0000 (0:00:00.019)       0:00:03.670 ************
fatal: [mariadb1]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'mariadb_short_version' is undefined. 'mariadb_short_version' is undefined
  
    The error appears to be in '/var/lib/home/bruno/git/paice-infrastructure/galaxy/roles/bodsch.mariadb/tasks/detect_mariadb_version.yml': line 34, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: mariadb version
      ^ here
```

I propose to run the task `detect available mariadb version` since it seems to be read-only.

## 2. `pip requirements installation failed`

`pip_requirements` is not defined since the task `create pip requirements file` does not run.
```
TASK [bodsch.mariadb : pip requirements installation failed] ********************************************************************************************************************************************************
Friday 30 May 2025  23:25:30 +0000 (0:00:00.204)       0:00:06.603 ************
fatal: [mariadb1]: FAILED! => 
  msg: |-
    The conditional check 'pip_install.failed' failed. The error was: error while evaluating conditional (pip_install.failed): 'pip_install' is undefined. 'pip_install' is undefined
  
    The error appears to be in '/var/lib/home/bruno/git/paice-infrastructure/galaxy/roles/bodsch.mariadb/tasks/install/python-support.yml': line 65, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
        - name: pip requirements installation failed
          ^ here

```

I propose to skip the block when in check mode since this should not create/change anything on the target host.